### PR TITLE
add two missing constants in py2.7

### DIFF
--- a/Lib/vanilla/py23.py
+++ b/Lib/vanilla/py23.py
@@ -30,3 +30,10 @@ try:
 except ImportError:
     def python_method(arg):
         return arg
+try:
+    print "import NSLayoutAttributeLastBaseline"
+    from AppKit import NSLayoutAttributeLastBaseline
+except ImportError:
+    import AppKit
+    AppKit.NSLayoutAttributeLastBaseline = 11
+    AppKit.NSLayoutAttributeFirstBaseline = 12

--- a/Lib/vanilla/py23.py
+++ b/Lib/vanilla/py23.py
@@ -30,10 +30,3 @@ try:
 except ImportError:
     def python_method(arg):
         return arg
-try:
-    print "import NSLayoutAttributeLastBaseline"
-    from AppKit import NSLayoutAttributeLastBaseline
-except ImportError:
-    import AppKit
-    AppKit.NSLayoutAttributeLastBaseline = 11
-    AppKit.NSLayoutAttributeFirstBaseline = 12

--- a/Lib/vanilla/vanillaBase.py
+++ b/Lib/vanilla/vanillaBase.py
@@ -1,14 +1,20 @@
 import platform
 from distutils.version import StrictVersion
-import py23
 from Foundation import NSObject
 from AppKit import NSFont, NSRegularControlSize, NSSmallControlSize, NSMiniControlSize, \
     NSViewMinXMargin, NSViewMaxXMargin, NSViewMaxYMargin, NSViewMinYMargin, \
     NSViewWidthSizable, NSViewHeightSizable, \
     NSLayoutConstraint, NSLayoutFormatAlignAllLeft, \
     NSLayoutAttributeLeft, NSLayoutAttributeRight, NSLayoutAttributeTop, NSLayoutAttributeBottom, NSLayoutAttributeLeading, NSLayoutAttributeTrailing, \
-    NSLayoutAttributeWidth, NSLayoutAttributeHeight, NSLayoutAttributeCenterX, NSLayoutAttributeCenterY, NSLayoutAttributeBaseline, NSLayoutAttributeLastBaseline, NSLayoutAttributeFirstBaseline, \
+    NSLayoutAttributeWidth, NSLayoutAttributeHeight, NSLayoutAttributeCenterX, NSLayoutAttributeCenterY, NSLayoutAttributeBaseline, \
     NSLayoutRelationLessThanOrEqual, NSLayoutRelationEqual, NSLayoutRelationGreaterThanOrEqual
+
+try:
+    from AppKit import NSLayoutAttributeLastBaseline
+except ImportError:
+    NSLayoutAttributeLastBaseline = 11
+    NSLayoutAttributeFirstBaseline = 12
+
 from vanilla.nsSubclasses import getNSSubclass
 
 

--- a/Lib/vanilla/vanillaBase.py
+++ b/Lib/vanilla/vanillaBase.py
@@ -1,5 +1,6 @@
 import platform
 from distutils.version import StrictVersion
+import py23
 from Foundation import NSObject
 from AppKit import NSFont, NSRegularControlSize, NSSmallControlSize, NSMiniControlSize, \
     NSViewMinXMargin, NSViewMaxXMargin, NSViewMaxYMargin, NSViewMinYMargin, \


### PR DESCRIPTION
The system pyobjc bridge misses this two