### PR TITLE
Fix visual artifacts after pane toggle

### DIFF
--- a/Lib/vanilla/vanillaSplitView.py
+++ b/Lib/vanilla/vanillaSplitView.py
@@ -578,6 +578,7 @@ class SplitView(VanillaBaseObject):
         if animate:
             warn("Pane animation is not supported at this time.")
         self.getNSSplitView().setState_forPane_(onOff, identifier)
+        self._nsObject.setNeedsDisplay_(True)
 
     def togglePane(self, identifier, animate=False):
         """


### PR DESCRIPTION
If you toggle a pane, and the subviews don't cover the entire pane, artifacts of the divider remain visible. This PR forces a redraw.

Before toggle:

![image](https://user-images.githubusercontent.com/4246121/75519015-91c0fd80-5a02-11ea-9b7d-4b0959ec62f9.png)

After toggle, note the remaining trace of the divider in the top part:

![image](https://user-images.githubusercontent.com/4246121/75519037-9d142900-5a02-11ea-8c41-970a64814ae9.png)
