### PR TITLE
Dont use the contentView to add to rules but the _nsObject itself

### DIFF
--- a/Lib/vanilla/vanillaBase.py
+++ b/Lib/vanilla/vanillaBase.py
@@ -363,7 +363,7 @@ def _recursiveSetFrame(view):
 
 def _setAttr(cls, obj, attr, value):
     if hasattr(value, "getPosSize") and value.getPosSize() == "auto":
-        view = value._getContentView()
+        view = value._nsObject
         view.setTranslatesAutoresizingMaskIntoConstraints_(False)
         obj._autoLayoutViews[attr] = view
     if isinstance(value, VanillaBaseObject) and hasattr(value, "_posSize"):

--- a/Lib/vanilla/vanillaTabs.py
+++ b/Lib/vanilla/vanillaTabs.py
@@ -9,6 +9,7 @@ class VanillaTabItem(VanillaBaseObject):
     nsTabViewItemClass = NSTabViewItem
 
     def __init__(self, title):
+        self._autoLayoutViews = {}
         self._tabItem = self.nsTabViewItemClass.alloc().initWithIdentifier_(title)
         self._tabItem.setLabel_(title)
 
@@ -17,6 +18,7 @@ class VanillaTabItem(VanillaBaseObject):
 
     def _breakCycles(self):
         _breakCycles(self._tabItem.view())
+        self._autoLayoutViews.clear()
 
 
 class VanillaTabsDelegate(NSObject):


### PR DESCRIPTION
similar to what happens with a posSize approache: the child view, the _nsobject view, is added to the parent contentview

fixes #120 