### PR TITLE
expose drop operations

### DIFF
--- a/Lib/vanilla/vanillaList.py
+++ b/Lib/vanilla/vanillaList.py
@@ -137,6 +137,7 @@ class VanillaArrayController(NSArrayController):
             return NSDragOperationNone
         # unpack data
         dropInformation["data"] = self._unpackPboard(settings, draggingInfo)
+        dropInformation["operation"] = draggingInfo.draggingSourceOperationMask()
         # call the callback
         result = settings["callback"](vanillaWrapper, dropInformation)
         if result:


### PR DESCRIPTION
A drop setting can allow specific drop and based on modifierkeys the operation is different --> expose that value

all dropOperations: https://developer.apple.com/documentation/appkit/nsdragoperation?language=objc

fixes #123