### PR TITLE
Add support for copy pasting in apps running  with executeVanillaTest()

### DIFF
--- a/Lib/vanilla/test/testTools.py
+++ b/Lib/vanilla/test/testTools.py
@@ -1,5 +1,5 @@
 from Foundation import NSObject
-from AppKit import NSApplication, NSMenu, NSMenuItem, NSBundle, NSText
+from AppKit import NSApplication, NSMenu, NSMenuItem, NSBundle
 from PyObjCTools import AppHelper
 import asyncio
 

--- a/Lib/vanilla/test/testTools.py
+++ b/Lib/vanilla/test/testTools.py
@@ -10,7 +10,8 @@ except ImportError:
     hasCorefoundationasyncio = False
 
 
-class _VanillaMiniApp(NSApplication): pass
+class _VanillaMiniApp(NSApplication):
+    pass
 
 
 class _VanillaMiniAppDelegate(NSObject):
@@ -39,13 +40,13 @@ def executeVanillaTest(cls, nibPath=None, calls=None, **kwargs):
 
         editMenuItem = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_("Edit", None, "")
         editMenu = NSMenu.alloc().initWithTitle_("Edit")
-        editMenu.addItemWithTitle_action_keyEquivalent_('Cut', NSText.cut_, 'x')
-        editMenu.addItemWithTitle_action_keyEquivalent_('Copy', NSText.copy_, 'c')
-        editMenu.addItemWithTitle_action_keyEquivalent_("Paste", NSText.paste_, "v")
+        editMenu.addItemWithTitle_action_keyEquivalent_("Cut", "cut:", "x")
+        editMenu.addItemWithTitle_action_keyEquivalent_("Copy", "copy:", "c")
+        editMenu.addItemWithTitle_action_keyEquivalent_("Paste", "paste:", "v")
         editMenu.addItem_(NSMenuItem.separatorItem())
-        editMenu.addItemWithTitle_action_keyEquivalent_("Select All", NSText.selectAll_, "a")
+        editMenu.addItemWithTitle_action_keyEquivalent_("Select All", "selectAll:", "a")
         editMenuItem.setSubmenu_(editMenu)
-        mainMenu.addItem_(editMenuItem) 
+        mainMenu.addItem_(editMenuItem)
 
         helpMenuItem = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_("Help", None, "")
         helpMenu = NSMenu.alloc().initWithTitle_("Help")

--- a/Lib/vanilla/test/testTools.py
+++ b/Lib/vanilla/test/testTools.py
@@ -1,5 +1,5 @@
 from Foundation import NSObject
-from AppKit import NSApplication, NSMenu, NSMenuItem, NSBundle
+from AppKit import NSApplication, NSMenu, NSMenuItem, NSBundle, NSText
 from PyObjCTools import AppHelper
 import asyncio
 
@@ -39,8 +39,13 @@ def executeVanillaTest(cls, nibPath=None, calls=None, **kwargs):
 
         editMenuItem = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_("Edit", None, "")
         editMenu = NSMenu.alloc().initWithTitle_("Edit")
+        editMenu.addItemWithTitle_action_keyEquivalent_('Cut', NSText.cut_, 'x')
+        editMenu.addItemWithTitle_action_keyEquivalent_('Copy', NSText.copy_, 'c')
+        editMenu.addItemWithTitle_action_keyEquivalent_("Paste", NSText.paste_, "v")
+        editMenu.addItem_(NSMenuItem.separatorItem())
+        editMenu.addItemWithTitle_action_keyEquivalent_("Select All", NSText.selectAll_, "a")
         editMenuItem.setSubmenu_(editMenu)
-        mainMenu.addItem_(editMenuItem)
+        mainMenu.addItem_(editMenuItem) 
 
         helpMenuItem = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_("Help", None, "")
         helpMenu = NSMenu.alloc().initWithTitle_("Help")


### PR DESCRIPTION
Add support for copy pasting within `EditText()` in app bundles created by `executeVanillaTest()`

I know `executeVanillaTest()` was created mainly for testing purposes, I hope this is not outside of its scope.