### PR TITLE
Fix Tabs for Ventura.

### DIFF
--- a/Lib/vanilla/vanillaBase.py
+++ b/Lib/vanilla/vanillaBase.py
@@ -37,7 +37,7 @@ macVersion = platform.mac_ver()[0]
 if platform.system() != "Darwin":
     macVersion = "0.0"
 osVersionCurrent = version(macVersion)
-osVersion12_0 = version("12.0") 
+osVersion12_0 = version("12.0")
 osVersion10_16 = version("10.16")  # macOS11 Big Sur seems to be 10.16
 osVersion10_15 = version("10.15")
 osVersion10_14 = version("10.14")
@@ -66,10 +66,14 @@ class VanillaBaseObject(object):
         _delAttr(VanillaBaseObject, self, attr)
 
     def _setupView(self, classOrName, posSize, callback=None):
-        self._autoLayoutViews = {}
-        self._testForDeprecatedAttributes()
         cls = getNSSubclass(classOrName)
-        self._nsObject = cls(self)
+        view = cls(self)
+        self._setupInstantiatedView(view, posSize, callback=callback)
+
+    def _setupInstantiatedView(self, view, posSize, callback=None):
+        self._testForDeprecatedAttributes()
+        self._autoLayoutViews = {}
+        self._nsObject = view
         self._posSize = posSize
         self._setCallback(callback)
         self._setAutosizingFromPosSize(posSize)

--- a/Lib/vanilla/vanillaTabs.py
+++ b/Lib/vanilla/vanillaTabs.py
@@ -1,4 +1,3 @@
-import weakref
 from Foundation import NSObject
 from AppKit import NSViewController,\
     NSTabViewController, NSTabView, NSTabViewItem,\
@@ -15,15 +14,16 @@ from AppKit import NSViewController,\
     NSViewControllerTransitionSlideBackward,\
     NSFont
 from vanilla.vanillaBase import VanillaBaseObject, _breakCycles, _sizeStyleMap, VanillaCallbackWrapper, \
-        _reverseSizeStyleMap
+    _reverseSizeStyleMap
 from vanilla.nsSubclasses import getNSSubclass
 
 
 class VanillaTabView(NSTabView):
 
     def viewDidMoveToWindow(self):
-        wrapper = self.vanillaWrapper()
-        wrapper._positionViews()
+        if self.window() is not None:
+            wrapper = self.vanillaWrapper()
+            wrapper._positionViews()
         super().viewDidMoveToWindow()
 
 
@@ -125,6 +125,30 @@ class Tabs(VanillaBaseObject):
     +-----------+
     | "mini"    |
     +-----------+
+
+    **showTabs** Boolean representing if the tabview should display tabs.
+
+    **transitionStyle** A string rerpresenting a transition style between tabs.
+    The options are:
+
+    +-----------------+
+    | None            |
+    +-----------------+
+    | "crossfade"     |
+    +-----------------+
+    | "slideUp"       |
+    +-----------------+
+    | "slideDown"     |
+    +-----------------+
+    | "slideLeft"     |
+    +-----------------+
+    | "slideRight"    |
+    +-----------------+
+    | "slideForward"  |
+    +-----------------+
+    | "slideBackward" |
+    +-----------------+
+
     """
 
     nsTabViewClass = VanillaTabView
@@ -153,7 +177,6 @@ class Tabs(VanillaBaseObject):
         self._setSizeStyle(sizeStyle)
         self._tabViewController.setTransitionOptions_(_tabTransitionMap[transitionStyle])
         self._tabItems = []
-        contentRect = self._nsObject.contentRect()
         for title in titles:
             tab = self.vanillaTabItemClass(title)
             self._tabItems.append(tab)
@@ -192,9 +215,6 @@ class Tabs(VanillaBaseObject):
         if callback is not None:
             self._target = VanillaCallbackWrapper(callback)
             delegate = self._nsObject.delegate()
-            if delegate is None:
-                self._delegate = delegate = getNSSubclass(VanillaTabsDelegate).alloc().init()
-                self._nsObject.setDelegate_(delegate)
             delegate._target = self._target
 
     def _setSizeStyle(self, value):

--- a/Lib/vanilla/vanillaTabs.py
+++ b/Lib/vanilla/vanillaTabs.py
@@ -41,7 +41,6 @@ class VanillaTabItem(VanillaBaseObject):
     nsViewControllerClass = NSViewController
 
     def __init__(self, title):
-        self._haveSetFrame = False
         self._autoLayoutViews = {}
         self._tabItem = getNSSubclass(self.nsTabViewItemClass).alloc().initWithIdentifier_(title)
         self._tabItem.setVanillaWrapper_(self)
@@ -59,6 +58,7 @@ class VanillaTabItem(VanillaBaseObject):
         return self._tabItem.view()
 
     def _breakCycles(self):
+        self._nsObject = None
         _breakCycles(self._tabItem.view())
         self._autoLayoutViews.clear()
 
@@ -174,6 +174,9 @@ class Tabs(VanillaBaseObject):
 
     def _positionViews(self):
         contentRect = self.getNSTabView().contentRect()
+        # only do after the first because
+        # adjusting the first gives it
+        # incorrect positioning
         for item in self._tabItems[1:]:
             item._setFrame(contentRect)
 

--- a/Lib/vanilla/vanillaTabs.py
+++ b/Lib/vanilla/vanillaTabs.py
@@ -1,4 +1,4 @@
-from warnings import warn
+import weakref
 from Foundation import NSObject
 from AppKit import NSViewController,\
     NSTabViewController, NSTabView, NSTabViewItem,\
@@ -45,9 +45,15 @@ class VanillaTabItem(VanillaBaseObject):
 
 class VanillaTabViewController(NSTabViewController):
 
+    def tabView_willSelectTabViewItem_(self, tabView, tabViewItem):
+        # XXX do the vanilla positioning here and set a flag
+        # that indicates that it has been done.
+        super().tabView_willSelectTabViewItem_(tabView, tabViewItem)
+
     def tabView_didSelectTabViewItem_(self, tabView, tabViewItem):
         if hasattr(self, "_target"):
             self._target.action_(tabView.vanillaWrapper())
+        super().tabView_didSelectTabViewItem_(tabView, tabViewItem)
 
 
 _tabTransitionMap = {


### PR DESCRIPTION
This needs a thorough review. Ultimately the solution was to set the view frames relative to the tab view's contentRect. The contentRect is only available after the view moves to a window, so I wait until then to adjust the frames.