### PR TITLE
Use respondsToSelector instead of hasattr in _breakCycles.

### DIFF
--- a/Lib/vanilla/vanillaBase.py
+++ b/Lib/vanilla/vanillaBase.py
@@ -543,9 +543,8 @@ def _breakCycles(view):
     """
     Break cyclic references by deleting _target attributes.
     """
-    if hasattr(view, "vanillaWrapper"):
+    if view.respondsToSelector_("vanillaWrapper"):
         obj = view.vanillaWrapper()
-        if hasattr(obj, "_breakCycles"):
-            obj._breakCycles()
+        obj._breakCycles()
     for view in view.subviews():
         _breakCycles(view)


### PR DESCRIPTION
This addresses #145.

Closing the test window in the issue goes from taking 0.11 seconds to 0.01 seconds.